### PR TITLE
Capture pointblank validation steps in level-2/3 stubs

### DIFF
--- a/R/pointblank.R
+++ b/R/pointblank.R
@@ -79,7 +79,7 @@ get_pb_lines <- function(convo, level) {
   funs <- funs[!no_funs]
 
   edit_expect <- function(stub, fun) {
-    stub_prep <- paste0("(", "matches('", "^([A-Za-z]_){", level-1 ,"}", stub, "')")
+    stub_prep <- paste0("(", "matches('", "^([A-Za-z]+_){", level-1 ,"}", stub, "')")
     stub_prep <- ifelse(!grepl("\\(\\)", fun), paste0(stub_prep, ", "), stub_prep)
     final <- sub("\\(", stub_prep, fun)
     return(final)

--- a/tests/testthat/test-pb.R
+++ b/tests/testthat/test-pb.R
@@ -27,6 +27,37 @@ agent_yaml2 <-
   set_tbl(df2)
 agent_obj2  <- create_pb_agent(convo2, df2, level = 2)
 
+
+# validation checks with flipped schema (measure in level 2/3) ---------------
+
+dt_msr_in_lvl3 <- data.frame(car_name_id = numeric(), car_name_name = character(),
+                             passenger_name_cnt = numeric())
+dt_msr_in_lvl2 <- data.frame(car_id = numeric(), passenger_name_first = character(),
+                             passenger_cnt = numeric())
+
+
+cnv_msr_in_lvl3 <- structure(list(
+  level1 = list(car = NULL,
+                passenger = NULL),
+  level2 = list(name = NULL),
+  level3 = list(id = list(valid = "col_is_numeric()"),
+                cnt = list(valid = "col_is_numeric()"),
+                name = NULL)),
+  class = c("convo", "list"))
+
+cnv_msr_in_lvl2 <- structure(list(
+  level1 = list(car = NULL,
+                passenger = NULL),
+  level2 = list(id = list(valid = "col_is_numeric()"),
+                cnt = list(valid = "col_is_numeric()"),
+                name = NULL),
+  level3 = list(last = NULL,
+                first = NULL)),
+  class = c("convo", "list"))
+
+cagent3 <- create_pb_agent(cnv_msr_in_lvl2, dt_msr_in_lvl2, level = 2)
+cagent2 <- create_pb_agent(cnv_msr_in_lvl3, dt_msr_in_lvl3, level = 3)
+
 # tests when validation checks at level 1 ----
 test_that(
   "YAML agent find correct variables and data checks ", {
@@ -78,5 +109,26 @@ test_that(
                  c("col_is_date", rep(c("col_is_numeric", "col_vals_in_set"), each = 2)))
   }
 )
+
+# tests for validation checks with flipped schema (measure in level 2/3) ---------------
+
+test_that("Level 2 and 3 data frames match their respective convos", {
+  expect_equal(evaluate_convo(cnv_msr_in_lvl2, names(dt_msr_in_lvl2)) %>% unlist(),
+               character())
+  expect_equal(evaluate_convo(cnv_msr_in_lvl3, names(dt_msr_in_lvl3)) %>% unlist(),
+               character())
+})
+
+test_that("columns are captured for level 3 checks in pointblank", {
+  expect_equal(nrow(cagent3$validation_set), 2)
+  expect_setequal(sort(unlist(cagent3$validation_set$column)),
+                  c("car_id", "passenger_cnt"))
+})
+
+test_that("columns are captured for level 2 checks in pointblank", {
+  expect_equal(nrow(cagent2$validation_set), 2)
+  expect_setequal(sort(unlist(cagent2$validation_set$column)),
+                  c("car_name_id", "passenger_name_cnt"))
+})
 
 


### PR DESCRIPTION
This should fix the issue #2 where columns are not captured for pointblank validation steps when the validation condition is specified for level 2 or 3. 

I also added some tests, hopefully close enough in approach to your existing ones, but starting from a separate convo so as not to create confusion. I can rewrite them using YAML files if you would like?

What is not clear to me is why your existing tests we
